### PR TITLE
Added path escaping to accommodate whitespaces within the absolute pa…

### DIFF
--- a/e-k8s/tools/gatling/Makefile.mak
+++ b/e-k8s/tools/gatling/Makefile.mak
@@ -8,7 +8,7 @@ IMAGE_NAME=$(CREG)/scp-2021-jan-cmpt-756/gatling:$(GATLING_VER)
 DIR=../../gatling
 
 # Convert relative pathname to absolute
-ABS_DIR=$(realpath $(DIR))
+ABS_DIR="$(realpath $(DIR))"
 
 CLUSTER_IP=NONE
 USERS=1


### PR DESCRIPTION
…th of the gatling directory


# Bug Report
Bug report and its [fix](#bug-fix) are included in this pullrequest.

Gatling commands in Exercise 5 section _Giving our services an initial load_ do not complete due to failure to `find image '756:latest' locally`. Indicates that gatling images are not downloaded correctly.

- [Steps to reproduce](#steps-to-reproduce)
  * [Prerequisites](#prerequisites)
  * [Bug](#bug)
  * [Environment](#environment)
- [Expected Results](#expected-results)
- [Actual Results](#actual-results)
- [Bug Fix](#bug-fix)
------

## Steps to reproduce
### Prerequisites
Successful completion of all commands in Exercise 5 up to section _Giving our services an initial load_ 
1. Create AWS stack and dynamodb tables.
2. Create and configure cloud cluster (Azure) with _istio_ (as per Exercises 4 and 5).
3. Start Services `s1 s2 db gw`
4. Provision

### Bug 
Either/both of the commands:
~~~ bash
$ tools/gatling.sh 1 ReadMusicSim
$ tools/gatling.sh 1 ReadUserSim
~~~

### Environment
Local host: macOS High Sierra (10.13.6)
- Docker Desktop 3.0.4
- Docker Engine 20.10.2
- Kubernetes v.1.19.3

Cloud cluster environment: Azure
- azure-cli 2.17.1 
- region: _canadacentral_
- k8s version: 1.19.7

## Expected Results
As documented in Exercise 5 instructions.
~~~
$ tools/gatling.sh 1 ReadMusicSim
docker container run --detach --rm -v .../e-k8s/gatling/results:/opt/gatling/results -v .../e-k8s/gatling:/opt/gatling/user-files -v .../e-k8s/gatling/target:/opt/gatling/target -e CLUSTER_IP=52.228.103.222 -e USERS=1 -e SIM_NAME=ReadMusicSim --label gatling ghcr.io/scp-2021-jan-cmpt-756/gatling:3.4.2 -s proj756.ReadMusicSim > /tmp/123

*** Control-C out of the following when you've seen enough ***

docker container logs `cat /tmp/123` --follow
GATLING_HOME is set to /opt/gatling
Simulation proj756.ReadMusicSim started...

================================================================================
2021-02-14 23:50:12                                           5s elapsed
---- Requests ------------------------------------------------------------------
> Global                                                   (OK=4      KO=0     )
> RMusic 0                                                 (OK=1      KO=0     )
> RMusic 1                                                 (OK=1      KO=0     )
> RMusic 2                                                 (OK=1      KO=0     )
> RMusic 3                                                 (OK=1      KO=0     )

---- ReadMusic -----------------------------------------------------------------
[--------------------------------------------------------------------------]  0%
          waiting: 0      / active: 1      / done: 0     
================================================================================

^C
~~~

## Actual Results

~~~ bash
$ tools/gatling.sh 1 ReadMusicSim
docker container run --detach --rm -v .../CMPT 756 2021/Exercise 5/sfu-cmpt756.211/e-k8s/gatling/results:/opt/gatling/results -v .../CMPT 756 2021/Exercise 5/sfu-cmpt756.211/e-k8s/gatling:/opt/gatling/user-files -v .../CMPT 756 2021/Exercise 5/sfu-cmpt756.211/e-k8s/gatling/target:/opt/gatling/target -e CLUSTER_IP=20.48.140.88 -e USERS=1 -e SIM_NAME=ReadMusicSim --label gatling ghcr.io/scp-2021-jan-cmpt-756/gatling:3.4.2 -s proj756.ReadMusicSim > /tmp/123
Unable to find image '756:latest' locally
docker: Error response from daemon: pull access denied for 756, repository does not exist or may require 'docker login': denied: requested access to the resource is denied.
See 'docker run --help'.
make: *** [run] Error 125
~~~
~~~ bash
$ tools/gatling.sh 1 ReadUserSim
docker container run --detach --rm -v /Users/digi/Desktop/CMPT 756 2021/Exercise 5/sfu-cmpt756.211/e-k8s/gatling/results:/opt/gatling/results -v /Users/digi/Desktop/CMPT 756 2021/Exercise 5/sfu-cmpt756.211/e-k8s/gatling:/opt/gatling/user-files -v /Users/digi/Desktop/CMPT 756 2021/Exercise 5/sfu-cmpt756.211/e-k8s/gatling/target:/opt/gatling/target -e CLUSTER_IP=52.228.104.171 -e USERS=1 -e SIM_NAME=ReadUserSim --label gatling ghcr.io/scp-2021-jan-cmpt-756/gatling:3.4.2 -s proj756.ReadUserSim > /tmp/123
Unable to find image '756:latest' locally
docker: Error response from daemon: pull access denied for 756, repository does not exist or may require 'docker login': denied: requested access to the resource is denied.
See 'docker run --help'.
make: *** [run] Error 125
~~~

## Bug Fix
The problem is traced to whitespaces in the local directory absolute path (outside the repository), e.g. `.../CMPT 756 2021/Exercise 5/sfu-cmpt756.211/e-k8s/`.

The issue is resolved by escaping the absolute path in [`tools/gatling/Makefile.mak`](https://github.com/scp-2021-jan-cmpt-756/sfu-cmpt756.211/blob/311cc72ef0c16cdcc3f5fc84163abbd75af0ea95/e-k8s/tools/gatling/Makefile.mak#L11), replacing _Line 11_ `ABS_DIR=$(realpath $(DIR))` with `ABS_DIR="$(realpath $(DIR))"`

# Original
